### PR TITLE
(#19) Update vmfloaty to expect /api/v1 in URL for disk endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gem install vmfloaty
 Grabbing a token for authenticated pooler requests:
 
 ```
-floaty token get --user me --url https://vmpooler.mycompany.net
+floaty token get --user me --url https://vmpooler.mycompany.net/api/v1
 ```
 
 This command will then ask you to log in. If successful, it will return a token that you can save either in a dotfile or use with other cli commands.
@@ -55,7 +55,7 @@ This command will then ask you to log in. If successful, it will return a token 
 Grabbing vms:
 
 ```
-floaty get centos-7-x86_64=2 debian-7-x86_64=1 windows-10=3 --token mytokenstring --url https://vmpooler.mycompany.net
+floaty get centos-7-x86_64=2 debian-7-x86_64=1 windows-10=3 --token mytokenstring --url https://vmpooler.mycompany.net/api/v1
 ```
 
 ### vmfloaty dotfile
@@ -64,7 +64,7 @@ If you do not wish to continuely specify various config options with the cli, yo
 
 ```yaml
 #file at /Users/me/.vmfloaty.yml
-url: 'http://vmpooler.mycompany.net'
+url: 'http://vmpooler.mycompany.net/api/v1'
 user: 'brian'
 token: 'tokenstring'
 ```
@@ -143,7 +143,7 @@ end
 
 if __FILE__ == $0
   verbose = true
-  url = 'https://vmpooler.mycompany.net'
+  url = 'https://vmpooler.mycompany.net/api/v1'
   token = aquire_token(verbose, url)
   os = ARGV[0]
 

--- a/lib/vmfloaty/auth.rb
+++ b/lib/vmfloaty/auth.rb
@@ -6,7 +6,7 @@ class Auth
   def self.get_token(verbose, url, user, password)
     conn = Http.get_conn_with_auth(verbose, url, user, password)
 
-    resp = conn.post "/token"
+    resp = conn.post "token"
 
     res_body = JSON.parse(resp.body)
     if res_body["ok"]
@@ -26,7 +26,7 @@ class Auth
 
     conn = Http.get_conn_with_auth(verbose, url, user, password)
 
-    response = conn.delete "/token/#{token}"
+    response = conn.delete "token/#{token}"
     res_body = JSON.parse(response.body)
     if res_body["ok"]
       return res_body
@@ -45,7 +45,7 @@ class Auth
 
     conn = Http.get_conn(verbose, url)
 
-    response = conn.get "/token/#{token}"
+    response = conn.get "token/#{token}"
     res_body = JSON.parse(response.body)
 
     if res_body["ok"]

--- a/lib/vmfloaty/pooler.rb
+++ b/lib/vmfloaty/pooler.rb
@@ -6,7 +6,7 @@ class Pooler
   def self.list(verbose, url, os_filter=nil)
     conn = Http.get_conn(verbose, url)
 
-    response = conn.get '/vm'
+    response = conn.get 'vm'
     response_body = JSON.parse(response.body)
 
     if os_filter
@@ -37,7 +37,7 @@ class Pooler
       raise "No operating systems provided to obtain. See `floaty get --help` for more information on how to get VMs."
     end
 
-    response = conn.post "/vm/#{os_string}"
+    response = conn.post "vm/#{os_string}"
 
     res_body = JSON.parse(response.body)
     if res_body["ok"]
@@ -60,9 +60,19 @@ class Pooler
     conn.headers['X-AUTH-TOKEN'] = token
 
     response = conn.put do |req|
-      req.url "/vm/#{hostname}"
+      req.url "vm/#{hostname}"
       req.body = modify_body.to_json
     end
+
+    res_body = JSON.parse(response.body)
+    res_body
+  end
+
+  def self.disk(verbose, url, hostname, token, disk)
+    conn = Http.get_conn(verbose, url)
+    conn.headers['X-AUTH-TOKEN'] = token
+
+    response = conn.post "vm/#{hostname}/disk/#{disk}"
 
     res_body = JSON.parse(response.body)
     res_body
@@ -77,7 +87,7 @@ class Pooler
 
     hosts.each do |host|
       puts "Scheduling host #{host} for deletion"
-      response = conn.delete "/vm/#{host}"
+      response = conn.delete "vm/#{host}"
       res_body = JSON.parse(response.body)
       if res_body['ok']
         puts "Deletion for vm #{host} successfully scheduled"
@@ -107,7 +117,7 @@ class Pooler
   def self.query(verbose, url, hostname)
     conn = Http.get_conn(verbose, url)
 
-    response = conn.get "/vm/#{hostname}"
+    response = conn.get "vm/#{hostname}"
     res_body = JSON.parse(response.body)
 
     res_body
@@ -117,7 +127,7 @@ class Pooler
     conn = Http.get_conn(verbose, url)
     conn.headers['X-AUTH-TOKEN'] = token
 
-    response = conn.post "/vm/#{hostname}/snapshot"
+    response = conn.post "vm/#{hostname}/snapshot"
     res_body = JSON.parse(response.body)
     res_body
   end
@@ -126,7 +136,7 @@ class Pooler
     conn = Http.get_conn(verbose, url)
     conn.headers['X-AUTH-TOKEN'] = token
 
-    response = conn.post "/vm/#{hostname}/snapshot/#{snapshot_sha}"
+    response = conn.post "vm/#{hostname}/snapshot/#{snapshot_sha}"
     res_body = JSON.parse(response.body)
     res_body
   end

--- a/lib/vmfloaty/version.rb
+++ b/lib/vmfloaty/version.rb
@@ -1,6 +1,6 @@
 
 class Version
-  @version = '0.2.19'
+  @version = '0.3.0'
 
   def self.get
     @version

--- a/vmfloaty.gemspec
+++ b/vmfloaty.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'vmfloaty'
-  s.version = '0.2.19'
+  s.version = '0.3.0'
   s.authors = ['Brian Cain']
   s.email = ['brian.cain@puppetlabs.com']
   s.license = 'Apache'

--- a/vmfloaty.yml.example
+++ b/vmfloaty.yml.example
@@ -1,2 +1,3 @@
-url: 'http://vmpooler.example.com'
+url: 'http://vmpooler.example.com/api/v1'
 user: 'brian'
+token: 'token here'


### PR DESCRIPTION
This commit updates floaty to use a new endpoint to modify vms. Now you
can use the modify command to extend the disk space of a given vm. The
downside is this new endpoint only exists at /api/v1 on the pooler, and
the way Faraday works required an update to removing a leading slash for
each request endpoint. Users should update their URL in the floaty dot
file to include a /api/v1 at the end of the pooler url