### PR TITLE
Show tag values in `list --active`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'commander'
 gem 'faraday'
 
 gem 'rspec'
-gem 'webmock'
+gem 'webmock', '1.21.0'
 gem 'rake'
 
 gemspec

--- a/lib/vmfloaty/utils.rb
+++ b/lib/vmfloaty/utils.rb
@@ -51,6 +51,7 @@ class Utils
         vms[host]['template'] = vm_info[host]['template']
         vms[host]['lifetime'] = vm_info[host]['lifetime']
         vms[host]['running'] = vm_info[host]['running']
+        vms[host]['tags'] = vm_info[host]['tags']
       end
     end
     vms
@@ -64,8 +65,13 @@ class Utils
       template = info['template']
       lifetime = info['lifetime']
       running = info['running']
+      tags = info['tags'] || {}
 
-      puts "- #{vm}.#{domain} (#{template}, #{running}/#{lifetime} hours)"
+      tag_pairs = tags.map {|key,value| "#{key}: #{value}" }
+      duration = "#{running}/#{lifetime} hours"
+      metadata = [template, duration, *tag_pairs]
+
+      puts "- #{vm}.#{domain} (#{metadata.join(", ")})"
     end
   end
 end

--- a/spec/vmfloaty/utils_spec.rb
+++ b/spec/vmfloaty/utils_spec.rb
@@ -31,4 +31,61 @@ describe Utils do
       expect(Utils.generate_os_hash(host_arg)).to be_empty
     end
   end
+
+  describe '#prettyprint_hosts' do
+    let(:host_without_tags) { 'mcpy42eqjxli9g2' }
+    let(:host_with_tags)    { 'aiydvzpg23r415q' }
+    let(:url)               { 'http://pooler.example.com' }
+
+    let(:host_info_with_tags) do
+      {
+        host_with_tags => {
+          "template" => "redhat-7-x86_64",
+          "lifetime" => 48,
+          "running"  => 7.67,
+          "tags"     => {
+            "user" => "bob",
+            "role" => "agent"
+          },
+          "domain" => "delivery.puppetlabs.net"
+        }
+      }
+    end
+
+    let(:host_info_without_tags) do
+      {
+        host_without_tags => {
+          "template" => "ubuntu-1604-x86_64",
+          "lifetime" => 12,
+          "running"  => 9.66,
+          "domain"   => "delivery.puppetlabs.net"
+        }
+      }
+    end
+
+    let(:output_with_tags)    { "- #{host_with_tags}.delivery.puppetlabs.net (redhat-7-x86_64, 7.67/48 hours, user: bob, role: agent)" }
+    let(:output_without_tags) { "- #{host_without_tags}.delivery.puppetlabs.net (ubuntu-1604-x86_64, 9.66/12 hours)" }
+
+    it 'prints an output with host fqdn, template and duration info' do
+      allow(Utils).to receive(:get_vm_info).
+        with(host_without_tags, false, url).
+        and_return(host_info_without_tags)
+
+      expect(Utils).to receive(:puts).with("Running VMs:")
+      expect(Utils).to receive(:puts).with(output_without_tags)
+
+      Utils.prettyprint_hosts(host_without_tags, false, url)
+    end
+
+    it 'prints an output with host fqdn, template, duration info, and tags when supplied' do
+      allow(Utils).to receive(:get_vm_info).
+        with(host_with_tags, false, url).
+        and_return(host_info_with_tags)
+
+      expect(Utils).to receive(:puts).with("Running VMs:")
+      expect(Utils).to receive(:puts).with(output_with_tags)
+
+      Utils.prettyprint_hosts(host_with_tags, false, url)
+    end
+  end
 end


### PR DESCRIPTION
If tags exist this will add them as comma-space separated list of {key}: {value} pairs after the currently listed metadata. If there aren't tags for the vm there should be no change to the output.

I enable travis on my fork and tested out a couple different combinations. You can see my version of this PR here: https://github.com/justinstoller/vmfloaty/pull/1 Hopefully that info is helpful?