### PR TITLE
Show the status of pools with `floaty status`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'commander'
 gem 'faraday', '0.9.2'
+gem 'colorize', '~> 0.8'
 
 gem 'rspec'
 gem 'webmock', '1.21.0'


### PR DESCRIPTION
Previously, `floaty status` would simply pretty-print the JSON output of
the status request to the pooler. That data requires additional
parsing, either human or machine, in order to be able to deduce any
meaningful information about the state of the pooler.

This commit updates `floaty status` to visually represent the state of
pools, indicating which pools have nodes missing or being built. It also
prints the status summary message returned by the pooler, providing an
easy way to tell if everything is okay.

By default, this command will only show the state of pools that aren't
full. If `--verbose` is passed, it will show all pools. If the complete
status information provided by the API is desired, the `--json` option
will print the raw JSON output, preserving the previous functionality.

This also updates the status command to exit non-zero if the status is
not ok.