### PR TITLE
Bump commander version to clear up deprecation warnings

### DIFF
--- a/vmfloaty.gemspec
+++ b/vmfloaty.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency 'commander', '~> 4.3.0'
+  s.add_dependency 'commander', '~> 4.4.3'
   s.add_dependency 'faraday', '~> 0.9.0'
   s.add_dependency 'colorize', '~> 0.8.1'
 end


### PR DESCRIPTION
Getting warnings with commander 4.3.0:
```
floaty get centos-7-x86_64
/Users/highb/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/commander-4.3.8/lib/commander/user_interaction.rb:333: warning: constant ::NIL is deprecated
/Users/highb/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/commander-4.3.8/lib/commander/user_interaction.rb:333: warning: constant ::TRUE is deprecated
/Users/highb/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/commander-4.3.8/lib/commander/user_interaction.rb:333: warning: constant ::FALSE is deprecated
/Users/highb/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/commander-4.3.8/lib/commander/user_interaction.rb:333: warning: constant ::Fixnum is deprecated
/Users/highb/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/commander-4.3.8/lib/commander/user_interaction.rb:333: warning: constant ::Bignum is deprecated
- as9r7rigltr70zt.delivery.puppetlabs.net (centos-7-x86_64)
```

Bumping the version to the latest, 4.4.3, seems to clear them up.