### PR TITLE
Update pooler provider to throw an exception if the API returns non-OK

### DIFF
--- a/lib/vmfloaty/pooler.rb
+++ b/lib/vmfloaty/pooler.rb
@@ -72,7 +72,14 @@ class Pooler
     end
 
     res_body = JSON.parse(response.body)
-    res_body
+
+    if res_body['ok']
+      res_body
+    elsif response.status == 401
+      raise AuthError, "HTTP #{response.status}: The token provided could not authenticate to the pooler.\n#{res_body}"
+    else
+      raise ModifyError, "HTTP #{response.status}: Failed to modify VMs from the pooler vm/#{hostname}. #{res_body}"
+    end
   end
 
   def self.disk(verbose, url, hostname, token, disk)


### PR DESCRIPTION
Prior to this commit the API could fail and return `ok: false` but
floaty wouldn't recognize that as a failure.
This commit updates the pooler code to check for `ok` and raise and
error with the body of what the api returns if it's non-truthy.