### PR TITLE
ABS will sometimes return null values in the /status/queue endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemspec
 gem 'rake', :require => false
 
 group :test do
+  gem 'pry'
+  gem 'rb-readline'
   gem 'rspec', '~> 3.5.0'
   gem 'rubocop', '~> 0.52'
   gem 'webmock', '1.21.0'

--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -57,11 +57,19 @@ class ABS
     requests = JSON.parse(res.body)
 
     ret_val = []
-    requests.each do |req|
-      req_hash = JSON.parse(req)
-      next unless user == req_hash['request']['job']['user']
 
-      ret_val.push(req_hash)
+    requests.each do |req|
+      next if req == 'null'
+
+      req_hash = JSON.parse(req)
+
+      begin
+        next unless user == req_hash['request']['job']['user']
+
+        ret_val.push(req_hash)
+      rescue NoMethodError
+        puts "Warning: couldn't parse line returned from abs/status/queue: ".yellow
+      end
     end
 
     ret_val

--- a/spec/vmfloaty/abs_spec.rb
+++ b/spec/vmfloaty/abs_spec.rb
@@ -58,5 +58,39 @@ describe ABS do
       ]
       expect(ABS.all_job_resources_accounted_for(allocated_resources, hosts)).to eq(true)
     end
+
+    before :each do
+      @abs_url = 'https://abs.example.com'
+    end
+
+    describe '#test_abs_status_queue_endpoint' do
+      before :each do
+        # rubocop:disable Metrics/LineLength
+        @active_requests_response = '
+        [
+          "{ \"state\":\"allocated\",\"last_processed\":\"2019-12-16 23:00:34 +0000\",\"allocated_resources\":[{\"hostname\":\"take-this.delivery.puppetlabs.net\",\"type\":\"win-2012r2-x86_64\",\"engine\":\"vmpooler\"}],\"audit_log\":{\"2019-12-13 16:45:29 +0000\":\"Allocated take-this.delivery.puppetlabs.net for job 1576255517241\"},\"request\":{\"resources\":{\"win-2012r2-x86_64\":1},\"job\":{\"id\":\"1576255517241\",\"tags\":{\"user\":\"test-user\"},\"user\":\"test-user\",\"time-received\":1576255519},\"priority\":1}}",
+          "null",
+          "{\"state\":\"allocated\",\"last_processed\":\"2019-12-16 23:00:34 +0000\",\"allocated_resources\":[{\"hostname\":\"not-this.delivery.puppetlabs.net\",\"type\":\"win-2012r2-x86_64\",\"engine\":\"vmpooler\"}],\"audit_log\":{\"2019-12-13 16:46:14 +0000\":\"Allocated not-this.delivery.puppetlabs.net for job 1576255565159\"},\"request\":{\"resources\":{\"win-2012r2-x86_64\":1},\"job\":{\"id\":\"1576255565159\",\"tags\":{\"user\":\"not-test-user\"},\"user\":\"not-test-user\",\"time-received\":1576255566},\"priority\":1}}"
+        ]'
+        # rubocop:enable Metrics/LineLength
+        @token = 'utpg2i2xswor6h8ttjhu3d47z53yy47y'
+        @test_user = 'test-user'
+      end
+
+      it 'will skip a line with a null value returned from abs' do
+        stub_request(:get, 'https://abs.example.com/status/queue')
+          .to_return(:status => 200, :body => @active_requests_response, :headers => {})
+
+        ret = ABS.get_active_requests(false, @abs_url, @test_user)
+
+        expect(ret[0]).to include(
+          'allocated_resources' => [{
+            'hostname' => 'take-this.delivery.puppetlabs.net',
+            'type'     => 'win-2012r2-x86_64',
+            'engine'   => 'vmpooler',
+          }],
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Status

Ready for Merge

## Description

Fix a bug where ABS will sometimes return null values on the /status/queue endpoint and floaty was not catching that.

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@demophoon
@briancain
