### PR TITLE
Fix error with delete command for vmpooler and nspooler

### DIFF
--- a/lib/vmfloaty/abs.rb
+++ b/lib/vmfloaty/abs.rb
@@ -290,4 +290,16 @@ class ABS
     res = conn.get "host/#{hostname}"
     JSON.parse(res.body)
   end
+
+  def self.modify(_verbose, _url, _hostname, _token, _modify_hash)
+    raise NoMethodError, 'modify is not defined for ABS'
+  end
+
+  def self.disk(_verbose, _url, _hostname, _token, _disk)
+    raise NoMethodError, 'disk is not defined for ABS'
+  end
+
+  def self.revert(_verbose, _url, _hostname, _token, _snapshot_sha)
+    raise NoMethodError, 'revert is not defined for ABS'
+  end
 end

--- a/lib/vmfloaty/nonstandard_pooler.rb
+++ b/lib/vmfloaty/nonstandard_pooler.rb
@@ -77,7 +77,7 @@ class NonstandardPooler
     raise ModifyError, 'Configured service type does not support snapshots'
   end
 
-  def self.delete(verbose, url, hosts, token)
+  def self.delete(verbose, url, hosts, token, _user)
     raise TokenError, 'Token provided was nil; Request cannot be made to delete VM' if token.nil?
 
     conn = Http.get_conn(verbose, url)

--- a/lib/vmfloaty/pooler.rb
+++ b/lib/vmfloaty/pooler.rb
@@ -94,7 +94,7 @@ class Pooler
     res_body
   end
 
-  def self.delete(verbose, url, hosts, token)
+  def self.delete(verbose, url, hosts, token, _user)
     raise TokenError, 'Token provided was nil. Request cannot be made to delete vm' if token.nil?
 
     conn = Http.get_conn(verbose, url)

--- a/spec/vmfloaty/nonstandard_pooler_spec.rb
+++ b/spec/vmfloaty/nonstandard_pooler_spec.rb
@@ -274,7 +274,7 @@ describe NonstandardPooler do
         .with(:headers => @auth_token_headers)
         .to_return(:status => 200, :body => @delete_response_success, :headers => {})
 
-      request = NonstandardPooler.delete(false, @nspooler_url, 'sol11-7', 'token-value')
+      request = NonstandardPooler.delete(false, @nspooler_url, 'sol11-7', 'token-value', nil)
       expect(request['sol11-7']['ok']).to be true
     end
 
@@ -283,7 +283,7 @@ describe NonstandardPooler do
         .with(:headers => @auth_token_headers)
         .to_return(:status => 401, :body => @delete_response_failure, :headers => {})
 
-      request = NonstandardPooler.delete(false, @nspooler_url, 'fakehost', 'token-value')
+      request = NonstandardPooler.delete(false, @nspooler_url, 'fakehost', 'token-value', nil)
       expect(request['fakehost']['ok']).to be false
     end
   end

--- a/spec/vmfloaty/pooler_spec.rb
+++ b/spec/vmfloaty/pooler_spec.rb
@@ -119,11 +119,11 @@ describe Pooler do
         .with(:headers => { 'X-Auth-Token' => 'mytokenfile' })
         .to_return(:status => 200, :body => @delete_response_body_success, :headers => {})
 
-      expect(Pooler.delete(false, @vmpooler_url, ['fq6qlpjlsskycq6'], 'mytokenfile')).to eq @delete_response
+      expect(Pooler.delete(false, @vmpooler_url, ['fq6qlpjlsskycq6'], 'mytokenfile', nil)).to eq @delete_response
     end
 
     it 'raises a token error if no token provided' do
-      expect { Pooler.delete(false, @vmpooler_url, ['myfakehost'], nil) }.to raise_error(TokenError)
+      expect { Pooler.delete(false, @vmpooler_url, ['myfakehost'], nil, nil) }.to raise_error(TokenError)
     end
   end
 

--- a/spec/vmfloaty/vmfloaty_services_spec.rb
+++ b/spec/vmfloaty/vmfloaty_services_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# All of the interfaces for the different services must be the
+# same, otherwise there will be errors when you change the caller
+# for the services from services.rb.
+#
+
+require_relative '../../lib/vmfloaty/pooler'
+require_relative '../../lib/vmfloaty/abs'
+require_relative '../../lib/vmfloaty/nonstandard_pooler'
+
+shared_examples 'a vmfloaty service' do
+  it { is_expected.to respond_to(:delete).with(5).arguments }
+  it { is_expected.to respond_to(:disk).with(5).arguments }
+  it { is_expected.to respond_to(:list).with(3).arguments }
+  it { is_expected.to respond_to(:list_active).with(4).arguments }
+  it { is_expected.to respond_to(:modify).with(5).arguments }
+  it { is_expected.to respond_to(:retrieve).with(6).arguments }
+  it { is_expected.to respond_to(:revert).with(5).arguments }
+  it { is_expected.to respond_to(:query).with(3).arguments }
+  it { is_expected.to respond_to(:snapshot).with(4).arguments }
+  it { is_expected.to respond_to(:status).with(2).arguments }
+  it { is_expected.to respond_to(:summary).with(2).arguments }
+end
+
+describe Pooler do
+  subject { Pooler }
+  it_behaves_like 'a vmfloaty service'
+end
+
+describe ABS do
+  subject { ABS }
+  it_behaves_like 'a vmfloaty service'
+end
+
+describe NonstandardPooler do
+  subject { NonstandardPooler }
+  it_behaves_like 'a vmfloaty service'
+end


### PR DESCRIPTION
…e doing so, fix the broken interfaces for delete on vmpooler and nonstandard pooler(they were passed 5 by service.rb but expected 4)

## Status

Ready for Merge

## Description

There was a broken interface for vmfloaty's delete commands on nspooler and vmpooler after a 5th parameter was created on the abs delete command.  This adds a test to ensure that if something like this changes again, the test will catch it.

## Related Issues

-

## Todos

- [*] Tests
- [n/a] Documentation

## Reviewers

@demophoon
@briancain
@highb 
@jcoconnor
