### PR TITLE
SSH Command respects ABS now and tests should fail if the API changes…

### DIFF
--- a/lib/vmfloaty/service.rb
+++ b/lib/vmfloaty/service.rb
@@ -91,7 +91,7 @@ class Service
         STDERR.puts 'Could not get token... requesting vm without a token anyway...'
       end
     end
-    Ssh.ssh(verbose, host_os, token_value, url)
+    Ssh.ssh(verbose, self, host_os, token_value)
   end
 
   def pretty_print_running(verbose, hostnames = [])

--- a/lib/vmfloaty/ssh.rb
+++ b/lib/vmfloaty/ssh.rb
@@ -14,21 +14,27 @@ class Ssh
     nil
   end
 
-  def self.ssh(verbose, host_os, token, url)
+  def self.command_string(verbose, service, host_os, use_token)
     ssh_path = which('ssh')
     raise 'Could not determine path to ssh' unless ssh_path
 
     os_types = {}
     os_types[host_os] = 1
 
-    response = Pooler.retrieve(verbose, os_types, token, url)
-    raise "Could not get vm from vmpooler:\n #{response}" unless response['ok']
+    response = service.retrieve(verbose, os_types, use_token)
+    raise "Could not get vm from #{service.type}:\n #{response}" unless response['ok']
 
     user = /win/.match?(host_os) ? 'Administrator' : 'root'
 
-    hostname = "#{response[host_os]['hostname']}.#{response['domain']}"
-    cmd = "#{ssh_path} #{user}@#{hostname}"
+    hostname = response[host_os]['hostname']
+    hostname = response[host_os]['hostname'][0] if response[host_os]['hostname'].is_a?(Array)
+    hostname = "#{hostname}.#{response['domain']}" unless hostname.end_with?('puppetlabs.net')
 
+    "#{ssh_path} #{user}@#{hostname}"
+  end
+
+  def self.ssh(verbose, service, host_os, use_token)
+    cmd = command_string(verbose, service, host_os, use_token)
     # TODO: Should this respect more ssh settings? Can it be configured
     #       by users ssh config and does this respect those settings?
     Kernel.exec(cmd)

--- a/spec/vmfloaty/ssh_spec.rb
+++ b/spec/vmfloaty/ssh_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'vmfloaty/ssh'
+
+class ServiceStub
+  def retrieve(_verbose, os_types, _use_token)
+    if os_types.keys[0] == 'abs_host_string'
+      return {
+        os_types.keys[0] => { 'hostname' => ['abs-hostname.delivery.puppetlabs.net'] },
+        'ok'             => true,
+      }
+    end
+
+    {
+      os_types.keys[0] => { 'hostname' => 'vmpooler-hostname' },
+      'domain'         => 'delivery.puppetlabs.net',
+      'ok'             => true,
+    }
+  end
+
+  def type
+    return 'abs' if os_types == 'abs_host_string'
+    return 'vmpooler' if os_types == 'vmpooler_host_string'
+  end
+end
+
+describe Ssh do
+  before :each do
+  end
+
+  it 'gets a hostname string for abs' do
+    verbose = false
+    service = ServiceStub.new
+    host_os = 'abs_host_string'
+    use_token = false
+    cmd = Ssh.command_string(verbose, service, host_os, use_token)
+    expect(cmd).to match(/ssh root@abs-hostname.delivery.puppetlabs.net/)
+  end
+
+  it 'gets a hostname string for vmpooler' do
+    verbose = false
+    service = ServiceStub.new
+    host_os = 'vmpooler_host_string'
+    use_token = false
+    cmd = Ssh.command_string(verbose, service, host_os, use_token)
+    expect(cmd).to match(/ssh root@vmpooler-hostname.delivery.puppetlabs.net/)
+  end
+end


### PR DESCRIPTION
… again

## Proof
❰mikker❙~/Dev/vmfloaty(git:fix_ssh_command_breaking)❱✔≻ bin/floaty ssh ubuntu-1604-x86_64 --trace --service vmpooler
The authenticity of host 'blocky-armor.delivery.puppetlabs.net (10.16.115.120)' can't be established.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'blocky-armor.delivery.puppetlabs.net,10.16.115.120' (ECDSA) to the list of known hosts.
root@blocky-armor.delivery.puppetlabs.net's password:
❰mikker❙~/Dev/vmfloaty(git:fix_ssh_command_breaking)❱✘≻ bin/floaty ssh ubuntu-1604-x86_64 --trace --service abs
Requesting VMs with job_id: 1580167494644.  Will retry for up to an hour.
Waiting 1 seconds to check if ABS request has been filled.  Queue Position: 144... (x1)
Waiting 2 seconds to check if ABS request has been filled.  Queue Position: 144... (x2)
Waiting 3 seconds to check if ABS request has been filled.  Queue Position: 143... (x3)
The authenticity of host 'close-poison.delivery.puppetlabs.net (10.16.118.16)' can't be established.
Are you sure you want to continue connecting (yes/no)? no


## Status
Ready for Merge

## Description
The SSH Command was broken because the vmpooler api changed but it wasn't changed in the ssh command.  This PR:

* changes the ssh command to use the service object instead of the vmpooler object so it will work with ABS
* adds tests to ensure that this code path will alert if an API changes again.

## Related Issues

-

## Todos

- [ ] Tests
- [ ] Documentation

## Reviewers

@demophoon
@briancain
