### PR TITLE
Bump faraday dependency for Ruby 2.7 compatibility

### DIFF
--- a/vmfloaty.gemspec
+++ b/vmfloaty.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colorize', '~> 0.8.1'
   s.add_dependency 'commander', '~> 4.4.3'
-  s.add_dependency 'faraday', '~> 0.15.0'
+  s.add_dependency 'faraday', '~> 0.17.0'
 end


### PR DESCRIPTION
The only significant changes between 0.15.4 and 0.17.3 are silencing
some deprecation warnings on Ruby 2.7.