### PR TITLE
(maint) Fix modify --disk flag

### DIFF
--- a/lib/vmfloaty/pooler.rb
+++ b/lib/vmfloaty/pooler.rb
@@ -61,9 +61,9 @@ class Pooler
     conn = Http.get_conn(verbose, url)
     conn.headers['X-AUTH-TOKEN'] = token
 
-    if modify_hash['disk']
-      disk(verbose, url, hostname, token, modify_hash['disk'])
-      modify_hash.delete 'disk'
+    if modify_hash[:disk]
+      disk(verbose, url, hostname, token, modify_hash[:disk])
+      modify_hash.delete :disk
     end
 
     response = conn.put do |req|


### PR DESCRIPTION
When the modify hash is passed, it includes :disk as a symbol, rather than a string.  This fixes that, and allows the --disk flag to work again.

## Reviewers

@highb
@briancain
