### PR TITLE
DIO 2412- Ondemand and Priority flag added to SSH command

### DIFF
--- a/lib/vmfloaty.rb
+++ b/lib/vmfloaty.rb
@@ -470,6 +470,7 @@ class Vmfloaty
       c.option '--token STRING', String, 'Token for pooler service'
       c.option '--notoken', 'Makes a request without a token'
       c.option '--priority STRING', 'Priority for supported backends(ABS) (High(1), Medium(2), Low(3))'
+      c.option '--ondemand', 'Requested vms are provisioned upon receival of the request, tracked by a request ID'
       c.action do |args, options|
         verbose = options.verbose || config['verbose']
         service = Service.new(options, config)


### PR DESCRIPTION
## Status

Tested and reviewed

## Description

The ondemand and priority flag were added to the ssh command

## Related Issues

The --ondemand flag needs to be used in addition to the --service flag when using the get command if vmpooler.yml has abs listed as the first service. This is not the case for the ssh command.

## Todos

- [ x ] Tests

- [ ] Documentation

## Reviewers

@puppetlabs/dio
@highb
@briancain
