### PR TITLE
(PA-8499) Relax commander constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     vmfloaty (1.9.0)
-      commander (>= 4.4.3, < 4.7.0)
+      commander (>= 4.4.3, < 6)
       faraday (~> 2)
 
 GEM
@@ -13,8 +13,8 @@ GEM
     ast (2.4.3)
     bigdecimal (4.1.2)
     coderay (1.1.3)
-    commander (4.6.0)
-      highline (~> 2.0.0)
+    commander (5.0.0)
+      highline (~> 3.0.0)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -27,7 +27,7 @@ GEM
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     hashdiff (1.2.1)
-    highline (2.0.3)
+    highline (3.0.1)
     io-console (0.8.2)
     json (2.19.4)
     language_server-protocol (3.17.0.5)
@@ -100,6 +100,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
 

--- a/vmfloaty.gemspec
+++ b/vmfloaty.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 3.0'
 
-  s.add_dependency 'commander', '>= 4.4.3', '< 4.7.0'
+  s.add_dependency 'commander', '>= 4.4.3', '< 6'
   s.add_dependency 'faraday', '~> 2'
 end


### PR DESCRIPTION
## Summary

In Ruby 3.4, `abbrev` was promoted from a default gem to a bundled gem. `highline` 1.x/2.x require `abbrev` and now fail to load under Ruby 3.4 unless an explicit dependency on it is declared. `highline` 3.0 removed that dependency.

`commander` pins `highline` transitively: 4.x requires `highline ~> 2.0`, and only `commander` 5.0 requires `highline ~> 3.0`. Relaxing the upper bound to `< 6` lets vmfloaty resolve to `highline` 3.x on Ruby 3.4+ while still allowing `commander` 4.x for consumers that need it.

This unblocks consumers (e.g. `beaker-abs`) that need to pull in `highline >= 3.0` for Ruby 3.4+ support.

Jira: [PA-8499](https://perforce.atlassian.net/browse/PA-8499)

## Changes

- `vmfloaty.gemspec`: `commander '>= 4.4.3', '< 4.7.0'` → `commander '>= 4.4.3', '< 6'`
- `Gemfile.lock`: commander 4.6.0 → 5.0.0, highline 2.0.3 → 3.0.1 (bundler resolves to the newest version in range)

## Test plan

- [x] \`bundle exec rake spec\` — 139 examples, 0 failures
- [x] \`bundle exec floaty --help\` runs cleanly under commander 5.0
- [ ] CI green

## Notes

Closes #211 (the open dependabot PR that proposed the more conservative \`< 5.1.0\` cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)