### PR TITLE
(maint) Add Ruby 3.3, 3.4, and 4.0 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
+          - '4.0'
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemspec
 gem 'rake', require: false
 
 group :test do
+  # base64 is a bundled gem in Ruby >= 3.4, so it must be declared explicitly.
+  gem 'base64'
   gem 'simplecov', '~> 0.22.0'
   gem 'simplecov-html', '~> 0.13.1'
   gem 'simplecov-lcov', '~> 0.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    base64 (0.3.0)
     bigdecimal (4.1.2)
     coderay (1.1.3)
     commander (4.6.0)
@@ -100,10 +101,12 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
+  base64
   pry
   rake
   rb-readline


### PR DESCRIPTION
## Summary

Extend the CI test matrix to cover Ruby 3.3, 3.4, and 4.0 alongside the existing 3.0/3.1/3.2 jobs. This gives the project an early signal for compatibility regressions on currently-supported and upcoming Ruby releases.

Related: PA-8499 (commander/highline bump for Ruby 3.4 support) — once both PRs land, the matrix will actually exercise the constraint relaxation under Ruby 3.4.

## Test plan

- [ ] CI green across all six matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)